### PR TITLE
Track dependent files in @minna-ui/pre-style util

### DIFF
--- a/utils/pre-style/index.js
+++ b/utils/pre-style/index.js
@@ -38,8 +38,13 @@ module.exports = (context = {}) => async ({
       console.warn(warn.toString()); // eslint-disable-line no-console
     });
 
+    // pass through dependent files so rollup can monitor them for changes
+    /* eslint-disable-next-line no-underscore-dangle */
+    const dependencies = result.map ? result.map._sources._array : null;
+
     /* eslint-disable-next-line consistent-return */
     return {
+      dependencies,
       code: result.css,
       map: result.map,
     };

--- a/utils/pre-style/test/index.test.js
+++ b/utils/pre-style/test/index.test.js
@@ -1,5 +1,7 @@
 /** @jest-environment node */
 
+// TODO: Add test for returned `dependencies`
+
 'use strict';
 
 const fs = require('fs');

--- a/utils/rollup-plugins/lib/makeCss.js
+++ b/utils/rollup-plugins/lib/makeCss.js
@@ -53,7 +53,7 @@ function makeCss({
           this.warn(warn.toString(), { line: warn.line, column: warn.column });
         });
 
-        // this allows rollup to monitor files for changes in watch mode
+        // pass through dependent files so rollup can monitor them for changes
         /* eslint-disable-next-line no-underscore-dangle */
         const dependencies = result.map ? result.map._sources._array : null;
 

--- a/utils/rollup-plugins/test/makeCss.test.js
+++ b/utils/rollup-plugins/test/makeCss.test.js
@@ -2,6 +2,8 @@
 
 // FIXME: Write tests!
 
+// TODO: Add test for returned `dependencies`
+
 'use strict';
 
 describe('makeCss rollup plugin', () => {


### PR DESCRIPTION
This allows rollup to trigger a rebuild when in watch mode and a dependency changes.