### PR TITLE
Disable yarn cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,15 @@ jobs:
           node-version: ${{ matrix.node-version }}
       # - *cache-dir
       # - *cache-restore
-      - id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: v1-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            v1-${{ runner.os }}-yarn-
+      # - id: yarn-cache
+      # TODO: Fix issues about cache slowing down Windows and macOS builds
+      #   run: echo "::set-output name=dir::$(yarn cache dir)"
+      # - uses: actions/cache@v1
+      #   with:
+      #     path: ${{ steps.yarn-cache.outputs.dir }}
+      #     key: v1-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      #     restore-keys: |
+      #       v1-${{ runner.os }}-yarn-
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn run test-ci
@@ -59,14 +60,15 @@ jobs:
           node-version: 12
       # - *cache-dir
       # - *cache-restore
-      - id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: v1-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            v1-${{ runner.os }}-yarn-
+      # TODO: Enable cache
+      # - id: yarn-cache
+      #   run: echo "::set-output name=dir::$(yarn cache dir)"
+      # - uses: actions/cache@v1
+      #   with:
+      #     path: ${{ steps.yarn-cache.outputs.dir }}
+      #     key: v1-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      #     restore-keys: |
+      #       v1-${{ runner.os }}-yarn-
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn run lint


### PR DESCRIPTION
Kind of a bummer but overall reduces CI run time by ~4 min. Mostly due to the macOS yarn cache being way too big to store between CI runs.